### PR TITLE
Added ability for user to use their own Trakt api keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Ezra - Github/ezra-hubbard
 
 Kingpin - Github/wilson-fisk
 
+Umbrella - Github/UmbrellaPlug
+
 # Welcome to the *My Accounts* Project
 Kodi developers one stop shop for common account information accessed under one roof that all addons can share.  This allows users to setup accounts once and addons access that data.
 

--- a/lib/myaccounts/modules/trakt.py
+++ b/lib/myaccounts/modules/trakt.py
@@ -13,8 +13,8 @@ trakt_icon = control.joinPath(control.artPath(), 'trakt.png')
 class Trakt():
 	def __init__(self):
 		self.api_endpoint = 'https://api-v2launch.trakt.tv/%s'
-		self.client_id = 'e3a8d1c673dfecb7f669b23ecbf77c75fcfd24d3e8c3dbc7f79ed995262fa1db'
-		self.client_secret = '73bee6aeee29cb75db4d8771458a440017f7cfe842e85f457ed9d81f7910b349'
+		self.client_id = self.traktClientID()
+		self.client_secret = self.traktClientSecret()
 		self.expires_at = control.setting('trakt.expires')
 		self.token = control.setting('trakt.token')
 
@@ -39,7 +39,7 @@ class Trakt():
 					error_notification('', str(e))
 				return resp
 			timeout = 15.0
-			headers = {'Content-Type': 'application/json', 'trakt-api-version': '2', 'trakt-api-key': self.client_id}
+			headers = {'Content-Type': 'application/json', 'trakt-api-version': '2', 'trakt-api-key': self.traktClientID()}
 			response = send_query()
 			response.encoding = 'utf-8'
 			if return_str: return response
@@ -50,14 +50,14 @@ class Trakt():
 			log_utils.error()
 
 	def get_device_code(self):
-		data = {'client_id': self.client_id}
+		data = {'client_id': self.traktClientID()}
 		return self.call("oauth/device/code", data=data, with_auth=False)
 
 	def get_device_token(self, device_codes):
 		try:
 			data = {"code": device_codes["device_code"],
-					"client_id": self.client_id,
-					"client_secret": self.client_secret}
+					"client_id": self.traktClientID(),
+					"client_secret": self.traktClientSecret()}
 			start = time.time()
 			expires_in = device_codes['expires_in']
 			verification_url = control.lang(32513) % str(device_codes['verification_url'])
@@ -89,8 +89,8 @@ class Trakt():
 		traktRefresh = None
 		traktExpires = None
 		data = {
-			"client_id": self.client_id,
-			"client_secret": self.client_secret,
+			"client_id": self.traktClientID(),
+			"client_secret": self.traktClientSecret(),
 			"redirect_uri": "urn:ietf:wg:oauth:2.0:oob",
 			"grant_type": "refresh_token",
 			"refresh_token": control.setting('trakt.refresh')
@@ -211,3 +211,13 @@ class Trakt():
 		except:
 			log_utils.error()
 			return
+	def traktClientID(self):
+		traktId = 'e3a8d1c673dfecb7f669b23ecbf77c75fcfd24d3e8c3dbc7f79ed995262fa1db'
+		if (control.setting('trakt.client.id') != '' or control.setting('trakt.client.id') is not None) and control.setting('traktuserkey.enabled') == 'true':
+			traktId = control.setting('trakt.client.id')
+		return traktId
+	def traktClientSecret(self):
+		traktSecret = '73bee6aeee29cb75db4d8771458a440017f7cfe842e85f457ed9d81f7910b349'
+		if (control.setting('trakt.client.secret') != '' or control.setting('trakt.client.secret') is not None) and control.setting('traktuserkey.enabled') == 'true':
+			traktSecret = control.setting('trakt.client.secret')
+		return traktSecret

--- a/resources/language/Dutch/strings.po
+++ b/resources/language/Dutch/strings.po
@@ -427,3 +427,19 @@ msgstr "Configuratie"
 msgctxt "#40086"
 msgid "Account Expiry Notification"
 msgstr "Account Verlopen Notificatie"
+
+msgctxt "#40087"
+msgid "Trakt Client ID"
+msgstr ""
+
+msgctxt "#40088"
+msgid "Trakt Client Secret"
+msgstr ""
+
+msgctxt "#40089"
+msgid "Trakt API Key"
+msgstr ""
+
+msgctxt "#40090"
+msgid "Use Custom Trakt API Keys"
+msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -427,3 +427,19 @@ msgstr ""
 msgctxt "#40086"
 msgid "Account Expiry Notification"
 msgstr ""
+
+msgctxt "#40087"
+msgid "Trakt Client ID"
+msgstr ""
+
+msgctxt "#40088"
+msgid "Trakt Client Secret"
+msgstr ""
+
+msgctxt "#40089"
+msgid "Trakt API Key"
+msgstr ""
+
+msgctxt "#40090"
+msgid "Use Custom Trakt API Keys"
+msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -3,6 +3,9 @@
 	<!-- Trakt-0 -->
 	<category label ="32315">
 		<setting type="lsep" label="32315" />
+		<setting id="traktuserkey.enabled" type="bool" visible="eq(3,)" label="40090" default="false" />
+		<setting id="trakt.client.id" type="text" visible="eq(-1,true) + eq(2,)" label="40089" default="" />
+		<setting id="trakt.client.secret" type="text" visible="eq(-2,true)+ eq(1,)" option="hidden" label="40088" default="" />
 		<setting id="trakt.token" type="text" visible="false" label="" default="" />
 		<setting id="trakt.username" type="text" default="" label="40062" enable="false" visible="!eq(-1,)" />
 		<setting type="action" label="32316" action="RunScript(script.module.myaccounts, action=traktAcct)" visible="!eq(-2,)" />


### PR DESCRIPTION
Please try this out and let me know if you have any issues with it. Should be pretty straight forward change. Still defaults to the Ezra "My Accounts" key for trakt if the user does not select to use a custom one.